### PR TITLE
Setup Bug Fixes

### DIFF
--- a/ovos_PHAL_plugin_wifi_setup/__init__.py
+++ b/ovos_PHAL_plugin_wifi_setup/__init__.py
@@ -511,7 +511,8 @@ class WifiSetupPlugin(PHALPlugin):
         message = message or Message("test")
         self.enclosure.mouth_reset()
         # sync clock as soon as we have internet
-        self.bus.emit(message.forward("system.ntp.sync"))
+        self.bus.wait_for_response(message.forward("system.ntp.sync"),
+                                   "system.ntp.sync.complete")
         # We don't know if the user has configured setup, so we'll just emit a message for setup skill
         self.bus.emit(message.forward("ovos.wifi.setup.completed"))
         # Make sure the GUI spinner is dismissed
@@ -536,6 +537,7 @@ class WifiSetupPlugin(PHALPlugin):
 
     def shutdown(self):
         self.monitoring = False
-        self.bus.remove("mycroft.internet.connected", self.handle_internet_connected)
+        self.bus.remove("mycroft.internet.connected",
+                        self.handle_internet_connected)
         self.stop_setup()
         super().shutdown()

--- a/ovos_PHAL_plugin_wifi_setup/__init__.py
+++ b/ovos_PHAL_plugin_wifi_setup/__init__.py
@@ -251,9 +251,9 @@ class WifiSetupPlugin(PHALPlugin):
             }))
 
             # Update the GUI so client selection has all options
-            if self.gui.get("clients_model") is not None and \
-                    self.gui["clients_model"] != self.registered_clients:
-                LOG.debug(f"Updating GUI with new clients")
+            if self.gui.get('page_type') == "ModeChoose":
+                LOG.info(f"Updating GUI with new clients: "
+                         f"{self.registered_clients}")
                 self.gui["clients_model"] = self.registered_clients
             else:
                 LOG.debug(f"Not updating gui with clients: "
@@ -449,7 +449,7 @@ class WifiSetupPlugin(PHALPlugin):
                     if not self.is_connected_to_wifi():
                         LOG.info("LAUNCH SETUP")
                         try:
-                            self.launch_networking_setup()  # blocking
+                            self.launch_networking_setup()  # non-blocking
                             if self.first_boot:
                                 LOG.debug("First boot setup completed")
                                 self.first_boot = False

--- a/ovos_PHAL_plugin_wifi_setup/__init__.py
+++ b/ovos_PHAL_plugin_wifi_setup/__init__.py
@@ -255,6 +255,9 @@ class WifiSetupPlugin(PHALPlugin):
                     self.gui["clients_model"] != self.registered_clients:
                 LOG.debug(f"Updating GUI with new clients")
                 self.gui["clients_model"] = self.registered_clients
+            else:
+                LOG.debug(f"Not updating gui with clients: "
+                          f"{self.gui.get('clients_model')}")
             LOG.info("Registered wifi client: " + client_plugin_name)
 
     def handle_deregister_client(self, message=None):


### PR DESCRIPTION
Update clients_model updates to handle all cases when clients are missing from the GUI
Update ready checks to wait for setup completion to prevent loading spinner when connection event comes after ready event
Wait for ntp sync before reporting internet connection established